### PR TITLE
#11: Correct URL in POM (now leading to GitHub Project Page)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <name>Jython Maven Plugin</name>
     <description>Execute Python Scripts during Maven Build</description>
-    <url>http://juergen.rocks/maven-jython-plugin.html</url>
+    <url>https://github.com/juergen-rocks/jython-maven-plugin</url>
 
     <packaging>maven-plugin</packaging>
 


### PR DESCRIPTION
This fixes Bug #11 – and points the URL to the GitHub Project Page.