### PR TITLE
#14 Exception during direct invocation

### DIFF
--- a/src/main/java/rocks/juergen/maven/jythonplugin/JythonInterpreterToolbox.java
+++ b/src/main/java/rocks/juergen/maven/jythonplugin/JythonInterpreterToolbox.java
@@ -59,7 +59,12 @@ final class JythonInterpreterToolbox {
     static PythonInterpreter connectedInterpreterFactory(final String... pythonPathExtension) {
         final PySystemState pySysStat = new PySystemState();
         for (final String extension : pythonPathExtension) {
-            pySysStat.path.append(new PyString(extension));
+            if (extension != null) {
+                final String ex = extension.trim();
+                if (ex.length() > 0) {
+                    pySysStat.path.append(new PyString(ex));
+                }
+            }
         }
         return createConnectedInterpreter(pySysStat);
     }

--- a/src/test/java/rocks/juergen/maven/jythonplugin/TestExecuteMojoErrorBehaviour.java
+++ b/src/test/java/rocks/juergen/maven/jythonplugin/TestExecuteMojoErrorBehaviour.java
@@ -49,7 +49,7 @@ public class TestExecuteMojoErrorBehaviour extends AbstractMojoTest {
     public static List<Object[]> getParameters() {
         final ArrayList<Object[]> parameters = new ArrayList<>();
         parameters.add(new Object[]{null, MojoExecutionException.class});
-        parameters.add(new Object[]{"", IllegalArgumentException.class});
+        parameters.add(new Object[]{"", PyException.class});
         parameters.add(new Object[]{"/oh/no/this/does/not/exist.py", PyException.class});
         return parameters;
     }


### PR DESCRIPTION
Pulling the Bugfix for #14 into master:
* Only non-empty python path extensions are added to the SystemState